### PR TITLE
Update cluster example

### DIFF
--- a/cluster/seq-cluster-docker-compose/README.md
+++ b/cluster/seq-cluster-docker-compose/README.md
@@ -19,7 +19,7 @@ Usage
 1. Purchase [Seq Datacenter](https://datalust.co/pricing) or [start a trial](https://datalust.co/trial)
 1. Copy license certificate into a file called `cert.txt`
 1. `docker compose up`
-1. Browse [`http://localhost:5666`](http://localhost:5666)
+1. Browse [`http://localhost:5666`](http://localhost:5666) for Seq, [`http://localhost:5777`](http://localhost:5777) for the Seq diagnostic instance and [`http://localhost:8404/stats`](http://localhost:8404/stats) for the HAProxy dashboard.
 
 How it works
 ------------

--- a/cluster/seq-cluster-docker-compose/compose.yaml
+++ b/cluster/seq-cluster-docker-compose/compose.yaml
@@ -173,7 +173,7 @@ services:
       - POSTGRES_DB=seq
       - POSTGRES_PASSWORD=terminatorx
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready", "-U", "postgres", "-d", "seq"]
+      test: ["CMD", "pg_isready", "-U", "postgres", "-d", "seq"]
       interval: 5s
       timeout: 4s
       retries: 3
@@ -183,16 +183,16 @@ services:
     networks:
       - seqclusterdemo
     restart: "no"
-    command: [
-      "setting", 
-      "set",
-      "-n",
-      "InstanceTitle",
-      "-v",
-      "Diagnostics",
-      "-s",
-      "http://seqdiagnostics"
-    ]
+    entrypoint:
+      - /bin/seqcli/seqcli 
+      - setting  
+      - set
+      - -n
+      - InstanceTitle
+      - -v
+      - Diagnostics
+      - -s 
+      - http://seqdiagnostics
     depends_on: 
       seqdiagnostics:
         condition: service_healthy
@@ -207,15 +207,15 @@ services:
       seqdiagnostics:
         condition: service_healthy
     restart: "no"
-    command: [
-      "template", 
-      "import",
-      "--input",
-      "/templates",
-      "--merge",
-      "-s",
-      "http://seqdiagnostics"
-    ]
+    entrypoint:
+      - /bin/seqcli/seqcli 
+      - template  
+      - import
+      - --input
+      - /templates
+      - --merge
+      - -s 
+      - http://seqdiagnostics
 
   enabledetailedtracing:
     image: curlimages/curl

--- a/cluster/seq-cluster-docker-compose/haproxy/haproxy.cfg
+++ b/cluster/seq-cluster-docker-compose/haproxy/haproxy.cfg
@@ -9,6 +9,14 @@ defaults
   timeout server 90s
   log global
 
+frontend stats
+  mode http
+  bind :8404
+  stats enable
+  stats refresh 10s
+  stats uri /stats
+  stats show-modules
+
 frontend health
   mode http
   bind 127.0.0.1:5888


### PR DESCRIPTION
Fixes the postgres health check and the seqcli containers for setting the instance name and importing templates.

Adds the HAProxy dashbboard.